### PR TITLE
Simplify CV layout by removing header and showcase sections

### DIFF
--- a/cv.html
+++ b/cv.html
@@ -12,58 +12,12 @@
             background-color: #f4f4f4;
         }
         .container {
-            width: 80%;
+            width: 100%;
             margin: auto;
             overflow: hidden;
         }
-        header {
-            background: #333;
-            color: #fff;
-            padding-top: 30px;
-            min-height: 70px;
-            border-bottom: #77aaff 3px solid;
-        }
-        header a {
-            color: #fff;
-            text-decoration: none;
-            text-transform: uppercase;
-            font-size: 16px;
-        }
-        header ul {
-            padding: 0;
-            list-style: none;
-        }
-        header li {
-            float: left;
-            display: inline;
-            padding: 0 20px 0 20px;
-        }
-        header #branding {
-            float: left;
-        }
-        header #branding h1 {
-            margin: 0;
-        }
-        header nav {
-            float: right;
-            margin-top: 10px;
-        }
-        .showcase {
-            min-height: 400px;
-            background: url('showcase.jpg') no-repeat 0 -400px;
-            text-align: center;
-            color: #fff;
-        }
-        .showcase h1 {
-            margin-top: 100px;
-            font-size: 55px;
-            margin-bottom: 10px;
-        }
-        .showcase p {
-            font-size: 20px;
-        }
         .main {
-            padding: 20px;
+            padding: 40px;
             background: #fff;
             color: #333;
         }
@@ -92,26 +46,6 @@
     </style>
 </head>
 <body>
-    <header>
-        <div class="container">
-            <div id="branding">
-                <h1>John Doe</h1>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="#">Home</a></li>
-                    <li><a href="#">About</a></li>
-                    <li><a href="#">Contact</a></li>
-                </ul>
-            </nav>
-        </div>
-    </header>
-    <section class="showcase">
-        <div class="container">
-            <h1>Welcome to My CV</h1>
-            <p>Here you will find all the information about my professional experience and skills.</p>
-        </div>
-    </section>
     <section class="main">
         <div class="container">
             <h2>Professional Experience</h2>


### PR DESCRIPTION
Remove the header and showcase sections from `cv.html` and adjust the layout.

* Remove the entire `header` section including branding and navigation links.
* Remove the entire `showcase` section including background image and text.
* Adjust the `container` class width to 100%.
* Adjust the `main` section padding to 40px.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/thisisiron/thisisiron.github.io?shareId=XXXX-XXXX-XXXX-XXXX).